### PR TITLE
ensure valid json prediction output artefacts

### DIFF
--- a/azure/batch/scripts/predict_on_catalog.py
+++ b/azure/batch/scripts/predict_on_catalog.py
@@ -160,7 +160,7 @@ def save_predictions_to_json(predictions, image_ids, label_cols, save_loc):
     prediction_data = [ np.round(predictions[n, :3], decimals=3).tolist() for n in range(len(predictions)) ]
 
     # add the prediction data to the output data dict
-    output_data['data'] = { image_ids[n]: [probability_data[n], prediction_data[n]] for n in range(len(image_ids)) }
+    output_data['data'] = { image_ids[n]: [probability_data[n][0], prediction_data[n]] for n in range(len(image_ids)) }
     with open(save_loc, 'w') as out_file:
         json.dump(output_data, out_file)
 

--- a/azure/batch/scripts/predict_on_catalog.py
+++ b/azure/batch/scripts/predict_on_catalog.py
@@ -114,7 +114,7 @@ def save_predictions_to_json(predictions, image_ids, label_cols, save_loc):
       'schema': {
         'version': 1,
         'type': 'zooniverse/subject_assistant',
-        'data': { 'subject_id': ['probability_at_least_20pc_featured', ['smooth-or-featured-cd_smooth_prediction', 'smooth-or-featured-cd_featured-or-disk_prediction', 'smooth-or-featured-cd_problem_prediction'] ] }
+        'data': { 'subject_id': ['probability_at_least_20pc_featured', [['smooth-or-featured-cd_smooth_prediction'], ['smooth-or-featured-cd_featured-or-disk_prediction'], ['smooth-or-featured-cd_problem_prediction']] ] }
       }
       # will add the actual data under 'data' key, below
     }
@@ -334,28 +334,29 @@ def test_save_predictions_to_json():
     # predictions = np.random.rand(20, 3) * 100 + 1
 
     # some real predictions for Cosmic Dawn
-    predictions = np.array([[92.65231323,  3.26797128, 25.24700928],
-       [93.7562027 ,  3.7324903 , 33.72304916],
-       [82.39868164,  6.23918152, 20.55649376],
-       [73.68450928,  8.03439522, 20.93917465],
-       [76.07131958,  6.40088654, 29.8066597 ],
-       [54.40034485, 12.83099937, 13.50455379],
-       [90.39558411,  5.74498463, 40.09345245],
-       [44.36257935, 21.92322922, 14.49137306],
-       [57.88036728, 10.58429527, 14.5579319 ],
-       [15.32801437, 23.56198311,  7.74940348],
-       [76.99712372,  5.80586195, 47.61122131],
-       [80.41983795,  4.59404898, 42.60891342],
-       [91.29488373,  5.62464571, 37.56932831],
-       [17.39572906, 34.65762711,  8.72911072],  # this is index 14, likely to be featured
-       [54.37077332, 20.0857563 , 18.13856125],
-       [33.16508484,  7.55197144, 15.04645443],
-       [ 5.2865777 ,  2.25175548, 26.42889023],
-       [ 5.95480394,  2.10367179, 38.06949234],
-       [77.01819611,  5.05003738, 25.69354248],
-       [81.80924988,  5.31926441, 21.41218758]])
+    predictions = np.array([
+       [[92.65231323], [ 3.26797128], [25.24700928]],
+       [[ 93.7562027], [  3.7324903], [33.72304916]],
+       [[82.39868164], [ 6.23918152], [20.55649376]],
+       [[73.68450928], [ 8.03439522], [20.93917465]],
+       [[76.07131958], [ 6.40088654], [ 29.8066597]],
+       [[54.40034485], [12.83099937], [13.50455379]],
+       [[90.39558411], [ 5.74498463], [40.09345245]],
+       [[44.36257935], [21.92322922], [14.49137306]],
+       [[57.88036728], [10.58429527], [ 14.5579319]],
+       [[15.32801437], [23.56198311], [ 7.74940348]],
+       [[76.99712372], [ 5.80586195], [47.61122131]],
+       [[80.41983795], [ 4.59404898], [42.60891342]],
+       [[91.29488373], [ 5.62464571], [37.56932831]],
+       [[17.39572906], [34.65762711], [ 8.72911072]],  # this is index 14, likely to be featured
+       [[54.37077332], [ 20.0857563], [18.13856125]],
+       [[33.16508484], [ 7.55197144], [15.04645443]],
+       [[  5.2865777], [ 2.25175548], [26.42889023]],
+       [[ 5.95480394], [ 2.10367179], [38.06949234]],
+       [[77.01819611], [ 5.05003738], [25.69354248]],
+       [[81.80924988], [ 5.31926441], [21.41218758]]])
 
-    id_strs = [str(x) for x in range(20)]
+    id_strs = [str(x) for x in range(len(predictions))]
     label_cols = ['smooth-or-featured-cd_smooth', 'smooth-or-featured-cd_featured-or-disk', 'smooth-or-featured-cd_problem']
     save_loc = 'temp.json'
     save_predictions_to_json(predictions, id_strs, label_cols, save_loc)
@@ -366,7 +367,7 @@ def test_save_predictions_to_json():
     try:
       # 'data': { 'subject_id': ['probability_at_least_20pc_featured', [...predictions] ] }
       assert saved_preds['data']['14'][0] > 0.5
-      assert saved_preds['data']['14'][1] == [54.371, 20.086, 18.139]
+      assert saved_preds['data']['14'][1] == [[54.371], [20.086], [18.139]]
     finally:
       # cleanup the test file artefact
       os.unlink(save_loc)


### PR DESCRIPTION
This PR fixes a json serialization issues and updates the prediction results schema to 
1. take the first resulting probability value as there is only 1 that we are interested in
    + avoid `TypeError: Object of type ndarray is not JSON serializable` errors)
3. allow multiple prediction samples in output format schema 
    + I.e. n_samples defaults to 1 but can be greater, ensure our prediction list encodes this information in the output format.

