### PR TITLE
Error reporting and wait for preparation task completion

### DIFF
--- a/azure/batch/scripts/predict_catalog_with_model.py
+++ b/azure/batch/scripts/predict_catalog_with_model.py
@@ -33,6 +33,12 @@ if __name__ == '__main__':
     parser.add_argument('--devices', default=1, type=int)
     args = parser.parse_args()
 
+    # setup the error reporting tool - https://app.honeybadger.io/projects/
+    honeybadger_api_key = os.getenv('HONEYBADGER_API_KEY')
+    if honeybadger_api_key:
+        from honeybadger import honeybadger
+        honeybadger.configure(api_key=honeybadger_api_key)
+
     logging.info(f'Begin predictions on catalog: {args.catalog_url}')
 
     # load the catalog from a remote JSON url

--- a/azure/batch/scripts/train_model_finetune_on_catalog.py
+++ b/azure/batch/scripts/train_model_finetune_on_catalog.py
@@ -38,6 +38,12 @@ if __name__ == '__main__':
     parser.add_argument('--debug', dest='debug', default=False, action='store_true')
     args = parser.parse_args()
 
+    # setup the error reporting tool - https://app.honeybadger.io/projects/
+    honeybadger_api_key = os.getenv('HONEYBADGER_API_KEY')
+    if honeybadger_api_key:
+        from honeybadger import honeybadger
+        honeybadger.configure(api_key=honeybadger_api_key)
+
     # load csv file catalog location into a pandas data frame
     kade_catalog = pd.read_csv(args.catalog_loc)
 

--- a/azure/batch/setup.py
+++ b/azure/batch/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     install_requires=[
         'zoobot[pytorch_cu113] >= 1.0', # the big cheese - bring in the zoobot!
         'requests >= 2.28.1', # used to download prediction images from a remote URL
-        'h5py >= 3.7.0' # used for prediction exports
+        'h5py >= 3.7.0',  # used for prediction exports
+        'honeybadger' # used for error reporting
     ]
 )

--- a/azure/batch/setup.py
+++ b/azure/batch/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
     install_requires=[
         'zoobot[pytorch_cu113] >= 1.0', # the big cheese - bring in the zoobot!
         'requests >= 2.28.1', # used to download prediction images from a remote URL
-        'h5py >= 3.7.0',  # used for prediction exports
         'honeybadger' # used for error reporting
     ]
 )


### PR DESCRIPTION
closes #15 and #10

This PR adds Honeybadger error reporting to the batch scripts to surface errors in the batch processing python code. 

Finally this PR also adds a configurable wait time on main task start. This is needed as we don't currently wait for the job preparation task to complete successfully as it leaves the node pool scaled if it doesn't finish properly

so we're adding a configurable wait time on the main task start to allow the preparation task to finish and make the training / prediction code available.

Without this the main task can run before the job preparation task has finished and we get errors like "python: can't open file '/mnt/batch/tasks/shared/train_model_finetune_on_catalog.py': [Errno 2] No such file or directory""