### PR TITLE
Fix Prediction Job Failures (Aug 2024)

### DIFF
--- a/bajor/batch/predictions.py
+++ b/bajor/batch/predictions.py
@@ -95,8 +95,8 @@ def create_batch_job(job_id, manifest_url, pool_id):
         # Short term: avoid waiting for this prep task to complete before starting the main task
         # https://learn.microsoft.com/en-us/python/api/azure-batch/azure.batch.models.JobPreparationTask?view=azure-python#constructor
         # https://learn.microsoft.com/en-us/azure/batch/batch-job-task-error-checking#job-preparation-tasks
-        wait_for_success=False)
-
+        # wait_for_success=False) # REVERTED: due to failed prediction jobs that can't find data files
+        wait_for_success=True)
 
     # Job release task that runs after the job completes
     # NOTE: job release tasks are hard to debug as you can't easily extract the logs :(


### PR DESCRIPTION
Changes `wait_for_success` parameter on Azure batchmodel's `JobPreparationTask` from False (meant to save $$$ in case job prep code failed and left node running indefinitely) to True (wait for file copying to complete before running prediction task). 

This change is made as an attempt to fix prediction job failures that appear tied to missing file failures (e.g., `RuntimeError: DataLoader timed out after 600 seconds`). The solution tried here fits the symptoms of the failure: rerunning jobs leads to success (just waiting seemed to fix the underlying problem) so perhaps some of the data files had not finished copying over via job preparation task causing the timeout failure.