### PR TITLE
add user_identity to task for elivated permissions

### DIFF
--- a/bajor/batch/predictions.py
+++ b/bajor/batch/predictions.py
@@ -91,7 +91,7 @@ def create_batch_job(job_id, manifest_url, pool_id, checkpoint_target='ZOOBOT_CH
         user_identity = batchmodels.UserIdentity(
            auto_user=batchmodels.AutoUserSpecification(
               scope=batchmodels.AutoUserScope.task,
-              elevation_level=batchmodels.ElevationLevel.admin
+              elevation_level=batchmodels.ElevationLevel.non_admin
            )
         ),
         #

--- a/bajor/batch/predictions.py
+++ b/bajor/batch/predictions.py
@@ -88,6 +88,12 @@ def create_batch_job(job_id, manifest_url, pool_id, checkpoint_target='ZOOBOT_CH
     job.job_preparation_task = batchmodels.JobPreparationTask(
         command_line=f'/bin/bash -c \"set -ex; {create_results_dir}; {copy_code_to_shared_dir}\"',
         constraints=batchmodels.TaskConstraints(max_task_retry_count=3),
+        user_identity = batchmodels.UserIdentity(
+           auto_user=batchmodels.AutoUserSpecification(
+              scope=batchmodels.AutoUserScope.task,
+              elevation_level=batchmodels.ElevationLevel.admin
+           )
+        ),
         #
         # A busted preparation task means the main task won't launch...ever!
         # and leave the node in a scaled state costing $$ ££

--- a/bajor/batch/train_finetuning.py
+++ b/bajor/batch/train_finetuning.py
@@ -116,6 +116,12 @@ def create_batch_job(job_id, manifest_container_path, pool_id, checkpoint_target
     job.job_preparation_task = batchmodels.JobPreparationTask(
         command_line=f'/bin/bash -c \"set -ex; {setup_pytorch_kernel_cache_dir}; {create_results_dir}; {copy_code_to_shared_dir}\"',
         constraints=batchmodels.TaskConstraints(max_task_retry_count=3),
+        user_identity = batchmodels.UserIdentity(
+           auto_user=batchmodels.AutoUserSpecification(
+              scope=batchmodels.AutoUserScope.task,
+              elevation_level=batchmodels.ElevationLevel.admin
+           )
+        ),
         #
         # A busted preparation task means the main task won't launch...ever!
         # and leave the node in a scaled state costing $$ ££

--- a/bajor/batch/train_finetuning.py
+++ b/bajor/batch/train_finetuning.py
@@ -119,7 +119,7 @@ def create_batch_job(job_id, manifest_container_path, pool_id, checkpoint_target
         user_identity = batchmodels.UserIdentity(
            auto_user=batchmodels.AutoUserSpecification(
               scope=batchmodels.AutoUserScope.task,
-              elevation_level=batchmodels.ElevationLevel.admin
+              elevation_level=batchmodels.ElevationLevel.non_admin
            )
         ),
         #


### PR DESCRIPTION
Adding user_identity to  solve the error from the logs(attached below). 

Doc reference: https://learn.microsoft.com/en-us/python/api/azure-batch/azure.batch.models.jobpreparationtask?view=azure-python

[job_35ef19a3-6923-43b6-bea9-6c484c6cd1b0_task_1_stderr.txt](https://github.com/user-attachments/files/18153845/job_35ef19a3-6923-43b6-bea9-6c484c6cd1b0_task_1_stderr.txt)
