### PR TITLE
create TrainingGalaxyDataset class to wrap GalaxyDataset and convert images to RGB

### DIFF
--- a/azure/batch/scripts/predict_on_catalog.py
+++ b/azure/batch/scripts/predict_on_catalog.py
@@ -8,7 +8,8 @@ import json
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from PIL import Image
+from PIL import Image, ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 import numpy as np
 import pandas as pd

--- a/azure/batch/scripts/train_model_finetune_on_catalog.py
+++ b/azure/batch/scripts/train_model_finetune_on_catalog.py
@@ -9,7 +9,7 @@ from galaxy_datasets.transforms import default_view_config, GalaxyViewTransform
 
 from zoobot.pytorch.training import finetune
 from zoobot.shared.schemas import cosmic_dawn_ortho_schema, euclid_ortho_schema, gz_jwst_schema
-
+from train_on_catalog import TrainingGalaxyDataModule
 if __name__ == '__main__':
 
     logging.basicConfig(
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     except json.JSONDecodeError as e:
         logging.error(f"Invalid fixed_crop JSON: {args.fixed_crop}")
 
-    datamodule = GalaxyDataModule(
+    datamodule = TrainingGalaxyDataModule(
         label_cols=schema.label_cols,
         catalog=kade_catalog,
         batch_size=args.batch_size,

--- a/azure/batch/scripts/train_on_catalog.py
+++ b/azure/batch/scripts/train_on_catalog.py
@@ -1,0 +1,61 @@
+import logging
+from typing import Optional
+from PIL import Image
+from torch.utils.data import DataLoader
+from galaxy_datasets.pytorch import galaxy_dataset, galaxy_datamodule
+import numpy as np
+
+def open_image_as_rgb(path: str) -> Image.Image:
+    """Open image file and ensure it's RGB (3-channel)."""
+    img = Image.open(path)
+    if img.mode != 'RGB':
+        img = img.convert('RGB')
+    return img
+
+
+class TrainingGalaxyDataset(galaxy_dataset.GalaxyDataset):
+    def __init__(self, catalog, label_cols=None, transform=None, target_transform=None):
+        super().__init__(
+            catalog=catalog,
+            label_cols=label_cols,
+            transform=transform,
+            target_transform=target_transform
+        )
+
+    def __getitem__(self, idx):
+        galaxy = self.catalog.iloc[idx]
+        file_path = galaxy['file_loc']
+
+        # Load & convert to RGB
+        image = open_image_as_rgb(file_path)
+
+        label = galaxy[self.label_cols].astype(np.float32).values.squeeze()
+
+        # Apply transforms
+        if self.transform:
+            image = self.transform(image)
+        if self.target_transform:
+            label = self.target_transform(label)
+
+        return image, label
+
+
+class TrainingGalaxyDataModule(galaxy_datamodule.GalaxyDataModule):
+    def setup(self, stage: Optional[str] = None):
+        # First call base logic to populate catalogs and transforms
+        super().setup(stage)
+
+        # # For both fit *and* validate stages, ensure train/val datasets exist
+        if stage in (None, 'fit', 'validate'):
+            if self.train_catalog is not None:
+                self.train_dataset = TrainingGalaxyDataset(
+                    catalog=self.train_catalog,
+                    label_cols=self.label_cols,
+                    transform=self.train_transform
+                )
+            if self.val_catalog is not None:
+                self.val_dataset = TrainingGalaxyDataset(
+                    catalog=self.val_catalog,
+                    label_cols=self.label_cols,
+                    transform=self.test_transform
+                )


### PR DESCRIPTION
Converting images to RGB to ensure it matches what model expects.

Error `RuntimeError: Given groups=1, weight of size [80, 3, 4, 4], expected input[10, 4, 224, 224] to have 3 channels, but got 4 channels instead
`
Log file:
[job_090c60b2-4aa2-48d6-8ca4-89528792b841_task_1_stderr (1).txt](https://github.com/user-attachments/files/20040461/job_090c60b2-4aa2-48d6-8ca4-89528792b841_task_1_stderr.1.txt)


Also fixed the truncated image issue. See [here](https://pillow.readthedocs.io/en/stable/reference/ImageFile.html?utm_source=chatgpt.com#PIL.ImageFile.LOAD_TRUNCATED_IMAGES)

Error: `OSError: image file is truncated`

Log file:
[job_db00ed7c-e479-4af1-bedf-cf3bd555dcc6_task_1_stderr.txt](https://github.com/user-attachments/files/20050812/job_db00ed7c-e479-4af1-bedf-cf3bd555dcc6_task_1_stderr.txt)


Also add fix to exclude images with 404 status code on prediction run

Log File:
[job_a5dd64eb-d0f9-409d-8422-74270759779c_task_1_stderr.txt](https://github.com/user-attachments/files/20067917/job_a5dd64eb-d0f9-409d-8422-74270759779c_task_1_stderr.txt)

